### PR TITLE
Update DicewarePassword to use a cryptographic RNG

### DIFF
--- a/Modules/DicewarePassword/DicewarePassword.psm1
+++ b/Modules/DicewarePassword/DicewarePassword.psm1
@@ -1,7 +1,7 @@
 [System.Security.Cryptography.RandomNumberGenerator]$rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::Create()
 
 function Get-SecureRandom {
-
+	
 <#
 	.SYNOPSIS
 		Gets a cryptographically secure random number.
@@ -30,7 +30,7 @@ function Get-SecureRandom {
 		Last Update Notes:
 		- Created
 #>
-
+	
 	[CmdletBinding()]
 	param (
 		[Parameter(Position = 0, Mandatory = $false)]
@@ -39,36 +39,36 @@ function Get-SecureRandom {
 		[Parameter(Position = 1, Mandatory = $false)]
 		[System.Int32]$Minimum = 0
 	)
-
+	
 	PROCESS {
-
+		
 		if ($Maximum -le $Minimum) {
-
+			
 			Throw New-Object System.ArgumentException "The Minimum value ({$Minimum}) cannot be greater than or equal to the Maximum value ({$Maximum})."
-
+			
 		} # end if
-
-		[System.UInt32]$delta = $Maximum - $Minimum + 1
-		[System.UInt32]$upper = $delta * [System.Math]::Floor([System.UInt32]::MaxValue / $delta)
+		
+		[System.UInt64]$delta = $Maximum - $Minimum + 1
+		[System.UInt64]$upper = $delta * [System.Math]::Floor(([System.UInt32]::MaxValue + 1) / $delta)
 		$bytes = New-Object Byte[] 4
 		[System.UInt32]$value = 0
-
+		
 		do { # this loop avoids a bias when the range of values doesn't cleanly divide 2<<32
-
+			
 			$script:rng.GetBytes($bytes)
 			$value = [System.BitConverter]::ToUInt32($bytes, 0)
-
+			
 		} while ($value -gt $upper) # end do while loop
-
+		
 		return [System.Int32](($value % $delta) + $Minimum)
-
+		
 	} # end PROCESS block
-
+	
 } # end function Get-SecureRandom
 
 
 function Invoke-DiceRoll {
-
+	
 <#
 	.SYNOPSIS
 		Simulates a dice roll and returns a number based on the result of rolling the desired number of dice.
@@ -96,53 +96,53 @@ function Invoke-DiceRoll {
 		Last Update Notes:
 		- Uses a cryptographic RNG instead of Get-Random
 #>
-
+	
 	[CmdletBinding()]
 	param (
 		[Parameter(Position = 0, Mandatory = $false)]
 		[ValidateRange(1, 8)]
 		[System.Int32]$DiceCount = 5
 	)
-
+	
 	BEGIN {
-
+		
 		#Requires -Version 3
-
+		
 	} # end BEGIN block
-
+	
 	PROCESS {
-
+		
 		$i = 0
-
+		
 		Write-Verbose -Message "[Invoke-DiceRoll] Rolling dice; generating a {$DiceCount} digit random number."
 		try {
-
+			
 			$numberResult = $null
-
+			
 			for (; $i -lt $DiceCount; $i++) {
-
+				
 				$number = $null
 				$number = "$(Get-SecureRandom -Minimum 1 -Maximum 6)"
 				$numberResult += $number
-
+				
 			} # end for loop
-
+			
 			$numberResult
-
+			
 		} catch {
-
+			
 			Write-Warning -Message "[Invoke-DiceRoll][ERROR]Error generating random number. $_ "
-
+			
 		} # end try/catch
-
+		
 	} # end PROCESS block
-
+	
 	END {
-
+		
 		Write-Verbose -Message "[Invoke-DiceRoll] Processing Complete"
-
+		
 	} # end END block
-
+	
 } # end function Invoke-DiceRoll
 
 

--- a/Modules/DicewarePassword/DicewarePassword.psm1
+++ b/Modules/DicewarePassword/DicewarePassword.psm1
@@ -1,18 +1,85 @@
-﻿
+[System.Security.Cryptography.RandomNumberGenerator]$rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::Create()
+
+function Get-SecureRandom {
+
+<#
+	.SYNOPSIS
+		Gets a cryptographically secure random number.
+	.DESCRIPTION
+		The Get-SecureRandom cmdlet gets a randomly selected number using System.Security.Cryptography.RNGCryptoServiceProvider.
+		
+		Get-SecureRandom behaves similarly Get-Random, except that it doesn't accept a user-provided seed, choose items from a list, or produce anything other than 32-bit integers.
+	.PARAMETER  Maximum
+		The maximum value for the generated random number. This must be stricty greater than Minimum.
+	.PARAMETER  Minimum
+		The minimum value for the generated random number. This must be strictly less than Maximum.
+	.EXAMPLE
+		Get-SecureRandom -Maximum 100 -Minimum 1
+		99
+	.EXAMPLE
+		Get-SecureRandom
+		642640509
+	.OUTPUTS
+		System.Int32
+	.NOTES
+		Author: Alex Godofsky
+		Contact: https://github.com/AlexGodofsky
+		Version: 1.0
+		Last Updated: 20160621
+		Last Updated By: Alex Godofsky
+		Last Update Notes:
+		- Created
+#>
+
+	[CmdletBinding()]
+	param (
+		[Parameter(Position = 0, Mandatory = $false)]
+		[System.Int32]$Maximum = [System.Int32]::MaxValue,
+		
+		[Parameter(Position = 1, Mandatory = $false)]
+		[System.Int32]$Minimum = 0
+	)
+
+	PROCESS {
+
+		if ($Maximum -le $Minimum) {
+
+			Throw New-Object System.ArgumentException "The Minimum value ({$Minimum}) cannot be greater than or equal to the Maximum value ({$Maximum})."
+
+		} # end if
+
+		[System.UInt32]$delta = $Maximum - $Minimum + 1
+		[System.UInt32]$upper = $delta * [System.Math]::Floor([System.UInt32]::MaxValue / $delta)
+		$bytes = New-Object Byte[] 4
+		[System.UInt32]$value = 0
+
+		do { # this loop avoids a bias when the range of values doesn't cleanly divide 2<<32
+
+			$script:rng.GetBytes($bytes)
+			$value = [System.BitConverter]::ToUInt32($bytes, 0)
+
+		} while ($value -gt $upper) # end do while loop
+
+		return [System.Int32](($value % $delta) + $Minimum)
+
+	} # end PROCESS block
+
+} # end function Get-SecureRandom
+
+
 function Invoke-DiceRoll {
-	
+
 <#
 	.SYNOPSIS
 		Simulates a dice roll and returns a number based on the result of rolling the desired number of dice.
 	.DESCRIPTION
 		Simulates a dice roll and returns a number based on the result of rolling the desired number of dice.
-	
 		The default dice count is 5, which was driven by the Diceware Passphrase minimum word length recommendation. See the help for the 'New-DicewarePassword' cmdlet/function for more information.
 	.PARAMETER  DiceCount
 		The number of dice to roll
 	.EXAMPLE
 		Invoke-DiceRoll -DiceCount 8
-		51334144		
+		51334144
 	.EXAMPLE
 		Invoke-DiceRoll
 		31544
@@ -22,60 +89,60 @@ function Invoke-DiceRoll {
 		System.String
 	.NOTES
 		Author: Kevin Kirkpatrick
-		Contact: https://github.com/vScripter 
-		Version: 1.0
-		Last Updated: 20151027
-		Last Updated By: K. Kirkpatrick
+		Contact: https://github.com/vScripter
+		Version: 1.1
+		Last Updated: 20160621
+		Last Updated By: Alex Godofsky
 		Last Update Notes:
-		- Created
+		- Uses a cryptographic RNG instead of Get-Random
 #>
-	
+
 	[CmdletBinding()]
 	param (
 		[Parameter(Position = 0, Mandatory = $false)]
 		[ValidateRange(1, 8)]
 		[System.Int32]$DiceCount = 5
 	)
-	
+
 	BEGIN {
-		
-		#Requires -Version 3		
-		
+
+		#Requires -Version 3
+
 	} # end BEGIN block
-	
+
 	PROCESS {
-		
+
 		$i = 0
-		
+
 		Write-Verbose -Message "[Invoke-DiceRoll] Rolling dice; generating a {$DiceCount} digit random number."
 		try {
-			
+
 			$numberResult = $null
-			
+
 			for (; $i -lt $DiceCount; $i++) {
-				
+
 				$number = $null
-				$number = "$(Get-Random -Minimum 1 -Maximum 6)"
+				$number = "$(Get-SecureRandom -Minimum 1 -Maximum 6)"
 				$numberResult += $number
-				
+
 			} # end for loop
-			
+
 			$numberResult
-			
+
 		} catch {
-			
+
 			Write-Warning -Message "[Invoke-DiceRoll][ERROR]Error generating random number. $_ "
-			
-		} # end try/catch		
-		
+
+		} # end try/catch
+
 	} # end PROCESS block
-	
+
 	END {
-		
+
 		Write-Verbose -Message "[Invoke-DiceRoll] Processing Complete"
-		
+
 	} # end END block
-	
+
 } # end function Invoke-DiceRoll
 
 


### PR DESCRIPTION
Invoke-DiceRoll was using Get-Random. I've modified it to use an instance of System.Security.Cryptography.RNGCryptoServiceProvider (wrapped in a cmdlet Get-SecureRandom) instead.
